### PR TITLE
Update utils.py

### DIFF
--- a/uqload_dl/utils.py
+++ b/uqload_dl/utils.py
@@ -82,7 +82,7 @@ def is_uqload_url(url: str) -> bool:
     if url is None:
         return False
     uqload_regex = (
-        r"^https?://(www\.)?uqload\.(io|com|co)/(embed\-)?[a-zA-Z0-9]{12}\.(html)$"
+        r"^https?://(www\.)?uqload\.(io|com|co|to)/(embed\-)?[a-zA-Z0-9]{12}\.(html)$"
     )
     if not isinstance(url, str) or not re.match(uqload_regex, url):
         return False


### PR DESCRIPTION
I've seen this issue with links from UQload, now they can have `.to` url as well. I've fixed this on my local cloned project and it works.